### PR TITLE
Remove init_hardware from MCP23017 new()

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,27 @@ extern crate mcp23017;
 
 match mcp23017::MCP23017::default(i2c) {
     Ok(mut u) => {
+        u.init_hardware();
         u.pin_mode(1, mcp23017::PinMode::OUTPUT);   // for the first pin
         u.all_pin_mode(mcp23017::PinMode::OUTPUT);  // or for all pins
 
-        let status = multi.read_gpioab().unwrap();
+        let status = u.read_gpioab().unwrap();
         println!("all {:#?}", status).unwrap();
 
-        let read_a = multi.read_gpio(mcp23017::Port::GPIOA).unwrap();
+        let read_a = u.read_gpio(mcp23017::Port::GPIOA).unwrap();
         println!("port a {:#?}", read_a).unwrap();
 
-        match multi.write_gpioab(65503){
+        match u.write_gpioab(65503){
             Ok(_) => {
-                println!!("ok").unwrap();
+                println!("ok").unwrap();
             }
             _ => {
-                println!!("something wrong").unwrap();
+                println!("something wrong").unwrap();
             }
         }
     }
     Err(mcp23017::MCP23017::Error::BusError(error)) => {
-        println!!("{:#?}", error).unwrap();;
+        println!("{:#?}", error).unwrap();;
         panic!();
     }
     _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,6 @@ where
             address
         };
 
-        chip.init_hardware()?;
         Ok(chip)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ where
     where
         I2C: WriteRead<Error = E>,
     {
-        let mut chip = MCP23017 {
+        let chip = MCP23017 {
             com: i2c,
             address
         };
@@ -88,7 +88,7 @@ where
     }
 
     fn init_hardware(&mut self) -> Result<(), Error<E>> {
-	    // set all inputs to defaults on port A and B
+	// set all inputs to defaults on port A and B
         self.write_register(Register::IODIRA, 0xff)?;
 	    self.write_register(Register::IODIRB, 0xff)?;
 


### PR DESCRIPTION
`init_hardware` should be called independently from creating the resource. Users may not always want to set all IO to inputs whenever they start the application - preferring to read the current state and mutate that instead.