### PR TITLE
Simplify, clean up, fix a few things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,3 @@ exclude = [
 
 [dependencies]
 embedded-hal = "0.2.3"
-generic-array = "0.13.2"
-nb = "0.1.2"
-
-[dependencies.cast]
-default-features = false
-version = "0.2.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-//! Manages a new MCP23017, a 16-Bit I2C I/O Expander with Serial Interface module
+//! Manages a MCP23017, a 16-Bit I2C I/O Expander with Serial Interface module
 
 #![deny(
     missing_docs,
@@ -13,27 +13,15 @@
     unused_qualifications,
     warnings
 )]
-#![allow(
-    dead_code,
-    non_camel_case_types,
-)]
+#![allow(dead_code, non_camel_case_types)]
 
-extern crate cast;
 extern crate embedded_hal as ehal;
-extern crate generic_array;
-extern crate nb;
-
-use ::core::mem::MaybeUninit;
-
-use cast::u16;
 
 use ehal::blocking::i2c::{Write, WriteRead};
-use generic_array::typenum::consts::*;
-use generic_array::{ArrayLength, GenericArray};
 
-const ADDRESS_DEFAULT: u8 = 0x20;
-const LOW: u8 = 0;
-const HIGH: u8 = 1;
+const DEFAULT_ADDRESS: u8 = 0x20;
+const HIGH: bool = true;
+const LOW: bool = false;
 
 /// Struct for MCP23017. It provides 16-bit, general purpose parallel I/O expansion for I2C bus.
 /// It consists of multiple 8-bit configuration registers for input, output and polarity selection.
@@ -41,7 +29,7 @@ const HIGH: u8 = 1;
 /// bits (IODIRA/B). The data for each input or output is kept in the corresponding input or output
 /// register. The polarity of the Input Port register can be inverted with the Polarity Inversion register
 #[derive(Clone, Copy, Debug)]
-pub struct MCP23017<I2C: WriteRead> {
+pub struct MCP23017<I2C: Write + WriteRead> {
     com: I2C,
     /// lol
     pub address: u8,
@@ -69,28 +57,25 @@ where
     /// Creates an expander with default configuration
     pub fn default(i2c: I2C) -> Result<MCP23017<I2C>, Error<E>>
     where
-        I2C: WriteRead<Error = E>,
+        I2C: Write<Error = E> + WriteRead<Error = E>,
     {
-        MCP23017::new(i2c, ADDRESS_DEFAULT)
+        MCP23017::new(i2c, DEFAULT_ADDRESS)
     }
 
     /// Creates an expander with specific configuration
     pub fn new(i2c: I2C, address: u8) -> Result<MCP23017<I2C>, Error<E>>
     where
-        I2C: WriteRead<Error = E>,
+        I2C: Write<Error = E> + WriteRead<Error = E>,
     {
-        let chip = MCP23017 {
-            com: i2c,
-            address
-        };
+        let chip = MCP23017 { com: i2c, address };
 
         Ok(chip)
     }
 
     fn init_hardware(&mut self) -> Result<(), Error<E>> {
-	// set all inputs to defaults on port A and B
+        // set all inputs to defaults on port A and B
         self.write_register(Register::IODIRA, 0xff)?;
-	    self.write_register(Register::IODIRB, 0xff)?;
+        self.write_register(Register::IODIRB, 0xff)?;
 
         Ok(())
     }
@@ -101,25 +86,17 @@ where
         Ok(data[0])
     }
 
-    fn read_registers<N>(&mut self, reg: Register) -> Result<GenericArray<u8, N>, E>
-    where
-        N: ArrayLength<u8>,
-    {
-        let mut buffer: GenericArray<u8, N> = unsafe { MaybeUninit::<GenericArray<u8, N>>::uninit().assume_init() };
+    fn read_double_register(&mut self, reg: Register) -> Result<[u8; 2], E> {
+        let mut buffer: [u8; 2] = [0; 2];
 
-        {
-            let buffer: &mut [u8] = &mut buffer;
-            const I2C_AUTO_INCREMENT: u8 = 0;
-            self.com
-                .write_read(self.address, &[(reg as u8) | I2C_AUTO_INCREMENT], buffer)?;
-        }
+        self.com
+            .write_read(self.address, &[reg as u8], &mut buffer)?;
 
         Ok(buffer)
     }
 
     fn write_byte(&mut self, reg: Register, byte: u8) -> Result<(), E> {
-        let mut buffer = [0];
-        self.com.write_read(self.address, &[reg as u8, byte], &mut buffer)
+        self.com.write(self.address, &[reg as u8, byte])
     }
 
     fn read_byte(&mut self, reg: Register) -> Result<u8, E> {
@@ -128,26 +105,24 @@ where
         Ok(data[0])
     }
 
-    fn read_16bit(&mut self, reg: Register) -> Result<u16, E> {
-        let buffer: GenericArray<u8, U2> = self.read_registers(reg)?;
-        Ok((u16(buffer[0]) << 8) + u16(buffer[1]))
-    }
-
     fn write_register(&mut self, reg: Register, byte: u8) -> Result<(), E> {
-        let mut buffer = [0];
-        self.com.write_read(self.address, &[reg as u8, byte], &mut buffer)
+        self.com.write(self.address, &[reg as u8, byte])
     }
 
     fn write_16bit(&mut self, reg: Register, word: u16) -> Result<(), E> {
-        let mut buffer = [0];
         let msb = (word >> 8) as u8;
-        self.com
-            .write_read(self.address, &[reg as u8, word as u8, msb], &mut buffer)
+        self.com.write(self.address, &[reg as u8, word as u8, msb])
     }
 
     /// Updates a register associated with a pin (whether port A/B) reads its value,
     /// updates the particular bit, and writes its value
-    fn update_register_bit(&mut self, pin: u8, pin_value: u8, port_a_reg: Register, port_b_reg: Register) -> Result<(), E>  {  
+    fn update_register_bit(
+        &mut self,
+        pin: u8,
+        pin_value: bool,
+        port_a_reg: Register,
+        port_b_reg: Register,
+    ) -> Result<(), E> {
         let reg = register_for_pin(pin, port_a_reg, port_b_reg);
         let bit = bit_for_pin(pin);
         let reg_value = self.read_register(reg)?;
@@ -156,24 +131,29 @@ where
     }
 
     /// Sets the single pin mode to either Mode::INPUT or Mode::OUTPUT
-    pub fn pin_mode(&mut self, pin: u8, pin_mode: PinMode) -> Result<(), E>  {
-        self.update_register_bit(pin, pm(pin_mode), Register::IODIRA, Register::IODIRB)
+    pub fn pin_mode(&mut self, pin: u8, pin_mode: PinMode) -> Result<(), E> {
+        self.update_register_bit(
+            pin,
+            pin_mode.bit_value(),
+            Register::IODIRA,
+            Register::IODIRB,
+        )
     }
 
     /// Sets pin mode to either Mode::INPUT or Mode::OUTPUT
-    pub fn all_pin_mode(&mut self, pin_mode: PinMode) -> Result<(), E>  {
-        self.write_register(Register::IODIRA, pm(pin_mode))?;
-	    self.write_register(Register::IODIRB, pm(pin_mode))
+    pub fn all_pin_mode(&mut self, pin_mode: PinMode) -> Result<(), E> {
+        self.write_register(Register::IODIRA, pin_mode.register_value())?;
+        self.write_register(Register::IODIRB, pin_mode.register_value())
     }
 
     /// Reads all 16 pins (port A and B) into a single 16 bits variable
-    pub fn read_gpioab(&mut self) -> Result<u16, E>  {
-        let buffer: GenericArray<u8, U2> = self.read_registers(Register::GPIOA)?;
-        Ok((u16(buffer[0]) << 8) + u16(buffer[1]))
+    pub fn read_gpioab(&mut self) -> Result<u16, E> {
+        let buffer = self.read_double_register(Register::GPIOA)?;
+        Ok((buffer[0] as u16) << 8 + (buffer[1] as u16))
     }
 
     /// Reads a single port, A or B, and return its current 8 bit value
-    pub fn read_gpio(&mut self, port: Port) -> Result<u8, E>  {
+    pub fn read_gpio(&mut self, port: Port) -> Result<u8, E> {
         let reg = match port {
             Port::GPIOA => Register::GPIOA,
             _ => Register::GPIOB,
@@ -182,37 +162,37 @@ where
     }
 
     /// Writes all the pins with the value at the same time
-    pub fn write_gpioab(&mut self, value: u16) -> Result<(), E>  {
+    pub fn write_gpioab(&mut self, value: u16) -> Result<(), E> {
         self.write_16bit(Register::GPIOA, value)
     }
 
     /// Writes all the pins with the value at the same time for GPIOA
-    pub fn write_gpioa(&mut self, value: u8) -> Result<(), E>  {
+    pub fn write_gpioa(&mut self, value: u8) -> Result<(), E> {
         self.write_byte(Register::GPIOA, value)
     }
-    
+
     /// Writes all the pins with the value at the same time for GPIOB
-    pub fn write_gpiob(&mut self, value: u8) -> Result<(), E>  {
+    pub fn write_gpiob(&mut self, value: u8) -> Result<(), E> {
         self.write_byte(Register::GPIOB, value)
     }
 
     /// Writes digital value
-    pub fn digital_write(&mut self, pin: u8, value: u8) -> Result<(), E>  {
+    pub fn digital_write(&mut self, pin: u8, value: bool) -> Result<(), E> {
         let bit = bit_for_pin(pin);
         // read the current GPIO output latches
         let reg_ol = register_for_pin(pin, Register::OLATA, Register::OLATB);
         let gpio = self.read_register(reg_ol)?;
 
         // set the pin and direction
-	    let gpio_mod = write_bit(gpio, bit, value);
+        let gpio_mod = write_bit(gpio, bit, value);
 
         // write the new GPIO
-	    let reg_gp = register_for_pin(pin, Register::GPIOA, Register::GPIOB);
+        let reg_gp = register_for_pin(pin, Register::GPIOA, Register::GPIOB);
         self.write_register(reg_gp, gpio_mod)
     }
 
     /// Reads digital pin
-    pub fn digital_read(&mut self, pin: u8) -> Result<u8, E>  {
+    pub fn digital_read(&mut self, pin: u8) -> Result<u8, E> {
         let bit = bit_for_pin(pin);
         let reg = register_for_pin(pin, Register::GPIOA, Register::GPIOB);
         let value = self.read_register(reg)?;
@@ -222,7 +202,7 @@ where
     /// The GPPU register controls the pull-up resistors for the port pins.
     /// If a bit is set and the corresponding pin is configured as an input,
     /// the corresponding port pin is internally pulled up with a 100 kohm resistor
-    pub fn pull_up(&mut self, pin: u8, value: u8) -> Result<(), E>  {
+    pub fn pull_up(&mut self, pin: u8, value: bool) -> Result<(), E> {
         self.update_register_bit(pin, value, Register::GPPUA, Register::GPPUB)
     }
 
@@ -231,15 +211,26 @@ where
     /// open_drain will set the INT pin to value or open drain.
     /// polarity will set LOW or HIGH on interrupt.
     /// Default values after Power On Reset are: (false, false, LOW)
-    pub fn setup_interrupts(&mut self, mirroring: u8, open_drain: u8, polarity: Polarity) -> Result<(), E>  {
-        // configure the port A
+    pub fn setup_interrupts(
+        &mut self,
+        mirroring: bool,
+        open_drain: bool,
+        polarity: Polarity,
+    ) -> Result<(), E> {
+        // configure port A
         self.setup_interrupt_port(Register::IOCONA, mirroring, open_drain, p(polarity))?;
-	    
-        // configure the port B
+
+        // configure port B
         self.setup_interrupt_port(Register::IOCONB, mirroring, open_drain, p(polarity))
     }
 
-    fn setup_interrupt_port(&mut self, register: Register, mirroring: u8, open_drain: u8, polarity: u8) -> Result<(), E>  {
+    fn setup_interrupt_port(
+        &mut self,
+        register: Register,
+        mirroring: bool,
+        open_drain: bool,
+        polarity: bool,
+    ) -> Result<(), E> {
         let mut io_conf_value = self.read_register(register)?;
         io_conf_value = write_bit(io_conf_value, 6, mirroring);
         io_conf_value = write_bit(io_conf_value, 2, open_drain);
@@ -247,28 +238,38 @@ where
         self.write_register(register, io_conf_value)
     }
 
-    /// Sets up a pin for interrupt
+    /// Sets up a pin for interrupt.
     /// Note that the interrupt condition finishes when you read the information about
-    /// the port / value that caused the interrupt or you read the port itself
-    pub fn setup_interrupt_pin(&mut self, pin: u8, int_mode: InterruptMode) -> Result<(), E>  {
+    /// the port / value that caused the interrupt or you read the port itself.
+    pub fn setup_interrupt_pin(&mut self, pin: u8, int_mode: InterruptMode) -> Result<(), E> {
         // set the pin interrupt control (0 means change, 1 means compare against given value)
-        self.update_register_bit(pin, (im(int_mode) != im(InterruptMode::CHANGE)) as u8, Register::INTCONA, Register::INTCONB)?;
+        self.update_register_bit(
+            pin,
+            int_mode != InterruptMode::CHANGE,
+            Register::INTCONA,
+            Register::INTCONB,
+        )?;
 
         // in a RISING interrupt the default value is 0, interrupt is triggered when the pin goes to 1
-	    // in a FALLING interrupt the default value is 1, interrupt is triggered when pin goes to 0
-        self.update_register_bit(pin, (im(int_mode) == im(InterruptMode::FALLING)) as u8, Register::DEFVALA, Register::DEFVALB)?;
+        // in a FALLING interrupt the default value is 1, interrupt is triggered when pin goes to 0
+        self.update_register_bit(
+            pin,
+            int_mode == InterruptMode::FALLING,
+            Register::DEFVALA,
+            Register::DEFVALB,
+        )?;
 
         // enable the pin for interrupt
         self.update_register_bit(pin, HIGH, Register::GPINTENA, Register::GPINTENB)
     }
 
     /// Get last interrupt pin
-    pub fn get_last_interrupt_pin(&mut self) -> Result<u8, Error<E>>  {
+    pub fn get_last_interrupt_pin(&mut self) -> Result<u8, Error<E>> {
         // try port A
         let intf_a = self.read_register(Register::INTFA)?;
         for x in 0..8 {
             if read_bit(intf_a, x) > 0 {
-                return Ok(x)
+                return Ok(x);
             }
         }
 
@@ -276,16 +277,15 @@ where
         let intf_b = self.read_register(Register::INTFB)?;
         for x in 0..8 {
             if read_bit(intf_b, x) > 0 {
-                return Ok(x+8)
+                return Ok(x + 8);
             }
-
         }
 
         Err(Error::InterruptPinError)
     }
 
     /// Gets last interrupt value
-    pub fn get_last_interrupt_value(&mut self) -> Result<u8, Error<E>>  {
+    pub fn get_last_interrupt_value(&mut self) -> Result<u8, Error<E>> {
         match self.get_last_interrupt_pin() {
             Ok(pin) => {
                 let int_reg = register_for_pin(pin, Register::INTCAPA, Register::INTCAPB);
@@ -294,17 +294,16 @@ where
                 Ok((val >> bit) & 0x01)
             }
             Err(e) => Err(e),
-        } 
+        }
     }
 }
 
-fn write_bit(reg: u8, bit: u8, val: u8) -> u8 {
+fn write_bit(reg: u8, bit: u8, val: bool) -> u8 {
     let mut res = reg;
-    if val > 1 {
-      res |= 1 << bit;
-    }
-    else {
-      res &= !(1 << bit);
+    if val {
+        res |= 1 << bit;
+    } else {
+        res &= !(1 << bit);
     }
 
     res
@@ -317,7 +316,7 @@ fn read_bit(reg: u8, bit: u8) -> u8 {
 
 /// Returns bit number associated to a give pin
 fn bit_for_pin(pin: u8) -> u8 {
-	pin % 8
+    pin % 8
 }
 
 /// Returns register address, port dependent, for a given pin
@@ -333,28 +332,36 @@ fn register_for_pin(pin: u8, port_a_addr: Register, port_b_addr: Register) -> Re
 #[derive(Debug, Copy, Clone)]
 pub enum PinMode {
     /// Represent input mode
-    INPUT = 0,
+    INPUT = 1,
     /// Represent output mode
-    OUTPUT = 1,
+    OUTPUT = 0,
 }
 
-fn pm(pin_mode: PinMode) -> u8 {
-    pin_mode as u8
+impl PinMode {
+    fn bit_value(&self) -> bool {
+        match *self {
+            PinMode::INPUT => true,
+            PinMode::OUTPUT => false,
+        }
+    }
+
+    fn register_value(&self) -> u8 {
+        match *self {
+            PinMode::INPUT => 0xff,
+            PinMode::OUTPUT => 0x00,
+        }
+    }
 }
 
 /// Interrupt modes
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum InterruptMode {
-    /// Represent change mode
+    /// Represent change mode.
     CHANGE = 0,
-    /// Represent falling mode
+    /// Represent falling mode.
     FALLING = 1,
-    /// Represent rising mode
+    /// Represent rising mode.
     RISING = 2,
-}
-
-fn im(interrupt_mode: InterruptMode) -> u8 {
-    interrupt_mode as u8
 }
 
 /// Polarity modes
@@ -366,16 +373,19 @@ pub enum Polarity {
     HIGH = 1,
 }
 
-fn p(polarity: Polarity) -> u8 {
-    polarity as u8
+fn p(polarity: Polarity) -> bool {
+    match polarity {
+        Polarity::LOW => false,
+        Polarity::HIGH => true,
+    }
 }
 
 /// Generic port definition
 #[derive(Debug, Copy, Clone)]
 pub enum Port {
-    /// Represent GPIOA port generic definition
+    /// Represent GPIOA port generic definition.
     GPIOA,
-    /// Represent GPIOB port generic definition
+    /// Represent GPIOB port generic definition.
     GPIOB,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ where
     /// Reads all 16 pins (port A and B) into a single 16 bit variable.
     pub fn read_gpioab(&mut self) -> Result<u16, E> {
         let buffer = self.read_double_register(Register::GPIOA)?;
-        Ok((buffer[0] as u16) << 8 + (buffer[1] as u16))
+        Ok((buffer[0] as u16) << 8 | (buffer[1] as u16))
     }
 
     /// Reads a single port, A or B, and returns its current 8 bit value.


### PR DESCRIPTION
Alright, here's the PR. What this does:

- Use `bool` instead of `u8` for most of the single-bit binary values. I don't use the interrupt stuff on my device, so I didn't mess with that much.
- Fix `PinMode` constants being mixed up (fixes #2 )
- Fix `write_bit` to work correctly with the `HIGH` and `LOW` constants (fixes #3 )
- Improve documentation.
- Remove dependencies on everything but `embedded_hal`. This also removes the `unsafe` code needed for generic arrays.
- Rework `read_` and `write_` functions to have one variant for single registers and one for double registers each.
- Remove unused functions (`init_hardware` and maybe others too)
- Cargo fmt :)

It's a big one, and it's breaking, so... use at your own discretion :)

EDIT: I can squash these into one commit if you prefer