### PR TITLE
Add get_captured_value() function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,15 @@ where
             Err(e) => Err(e),
         }
     }
+
+    /// Get the complete value captured at the last interrupt of the specified port
+    pub fn get_captured_value(&mut self, port: Port) -> Result<u8, E> {
+        let reg = match port {
+            Port::GPIOA => Register::INTCAPA,
+            Port::GPIOB => Register::INTCAPB,
+        };
+        self.read_register(reg)
+    }
 }
 
 /// Changes the bit at position `bit` within `reg` to `val`.


### PR DESCRIPTION
This PR adds a new function `get_captured_value()` to the public interface of the MCP23017 type, extending the functionality for reading the captured input value after an input interrupt in the MC23017 IC. In contrast to `get_last_interrupt_value()`, the whole INTCAPA/B register is read, using with a single I2C read instruction.

In my application, this is useful, as I check all input states in a cyclic way, caching the previous input value in the software. Thus, its easier to read the full 8-bit value and compare it with the previous state than using `get_last_interrupt_pin()` and `get_last_interrupt_value()` to identify the changed bit that caused the interrupt. Reading only the current value, using `read_gpio()` is not sufficient, as I would miss short pulses on the input pins.