### PR TITLE
Update to embedded-hal 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ exclude = [
 ]
 
 [dependencies]
-embedded-hal = "0.2.3"
+embedded-hal = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 
 extern crate embedded_hal as ehal;
 
-use ehal::blocking::i2c::{Write, WriteRead};
+use ehal::i2c::I2c;
 
 /// The default I2C address of the MCP23017.
 const DEFAULT_ADDRESS: u8 = 0x20;
@@ -38,7 +38,7 @@ const LOW: bool = false;
 /// See the crate-level documentation for general info on the device and the operation of this
 /// driver.
 #[derive(Clone, Copy, Debug)]
-pub struct MCP23017<I2C: Write + WriteRead> {
+pub struct MCP23017<I2C: I2c> {
     com: I2C,
     /// The I2C slave address of this device.
     pub address: u8,
@@ -61,12 +61,12 @@ impl<E> From<E> for Error<E> {
 
 impl<I2C, E> MCP23017<I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
     /// Creates an expander with the default configuration.
     pub fn default(i2c: I2C) -> Result<MCP23017<I2C>, Error<E>>
     where
-        I2C: Write<Error = E> + WriteRead<Error = E>,
+        I2C: I2c<Error = E>,
     {
         MCP23017::new(i2c, DEFAULT_ADDRESS)
     }
@@ -74,7 +74,7 @@ where
     /// Creates an expander with specific address.
     pub fn new(i2c: I2C, address: u8) -> Result<MCP23017<I2C>, Error<E>>
     where
-        I2C: Write<Error = E> + WriteRead<Error = E>,
+        I2C: I2c<Error = E>,
     {
         let chip = MCP23017 { com: i2c, address };
 


### PR DESCRIPTION
Updates the embedded-hal dependency to the new stable version 1.0.0 from January 2024 and adapts the code to the reworked I2C trait structure. You can read more about the migration [over, at the embedded-hal repository](https://github.com/rust-embedded/embedded-hal/blob/5e21d566e25049a85a74010e0c92708f732b2a7f/docs/migrating-from-0.2-to-1.0.md).

Note: This change is not backwards compatible. However, users of this driver, who are stuck to a HAL implementation library based on embedded-hal 0.2.x, can use the [embedded-hal-compat crate](https://github.com/ryankurte/embedded-hal-compat) to adapt betweent the two versions of the traits.